### PR TITLE
added brain and mask output path args to brain extraction

### DIFF
--- a/brain_extraction/animaAtlasBasedBrainExtraction.py
+++ b/brain_extraction/animaAtlasBasedBrainExtraction.py
@@ -11,8 +11,9 @@ else:
 
 import glob
 import os
-from shutil import copyfile
+from shutil import copyfile, rmtree
 from subprocess import call, check_output
+import tempfile
 
 configFilePath = os.path.join(os.path.expanduser("~"), ".anima",  "config.txt")
 if not os.path.exists(configFilePath):
@@ -39,6 +40,12 @@ parser.add_argument('-S', '--second-step', action='store_true',
                     help="Perform second step of atlas based cropping (might crop part of the external part of the brain)")
 
 parser.add_argument('-i', '--input', type=str, required=True, help='File to process')
+parser.add_argument('-m', '--mask', type=str, help='Output path of the brain mask (default is inputName_brainMask.nrrd)')
+parser.add_argument('-b', '--brain', type=str, help='Output path of the masked brain (default is inputName_masked.nrrd)')
+parser.add_argument('-o', '--output', type=str, help="""Path where intermediate files (transformations, transformed images and rough mask) are stored 
+                    (default is an temporary directory created automatically and deleted after the process is finished ;
+                    intermediate files are deleted by default and kept if this option is given).
+                    """)
 
 args = parser.parse_args()
 
@@ -48,12 +55,25 @@ atlasImageMasked = animaExtraDataDir + "icc_atlas/Reference_T1_masked.nrrd"
 iccImage = animaExtraDataDir + "icc_atlas/BrainMask.nrrd"
 
 brainImage = args.input
+
+if not os.path.exists(brainImage):
+    sys.exit("Error: the image \"" + brainImage + "\" could not be found.")
+
 print("Brain masking image: " + brainImage)
 
 # Get floating image prefix
 brainImagePrefix = os.path.splitext(brainImage)[0]
 if os.path.splitext(brainImage)[1] == '.gz':
     brainImagePrefix = os.path.splitext(brainImagePrefix)[0]
+
+brainMask = args.mask if args.mask else brainImagePrefix + "_brainMask.nrrd"
+maskedBrain = args.brain if args.brain else brainImagePrefix + "_masked.nrrd"
+outputFolder = args.output if args.output else tempfile.mkdtemp()
+
+if not os.path.isdir(outputFolder):
+    os.mkdir(outputFolder)
+
+brainImagePrefix = os.path.join(outputFolder, os.path.basename(brainImagePrefix))
 
 # Decide on whether to use large image setting or small image setting
 command = [animaConvertImage, "-i", brainImage, "-I"]
@@ -114,16 +134,14 @@ if args.second_step is True:
     call(command)
 
     command = [animaApplyTransformSerie, "-i", iccImage, "-t", brainImagePrefix + "_nl_tr.xml", "-g", brainImage, "-o",
-               brainImagePrefix + "_brainMask.nrrd", "-n", "nearest"]
+               brainMask, "-n", "nearest"]
     call(command)
 
-    command = [animaMaskImage, "-i", brainImage, "-m", brainImagePrefix + "_brainMask.nrrd", "-o",
-               brainImagePrefix + "_masked.nrrd"]
+    command = [animaMaskImage, "-i", brainImage, "-m", brainMask, "-o", maskedBrain]
     call(command)
 else:
-    copyfile(brainImageRoughMasked,brainImagePrefix + "_masked.nrrd")
-    copyfile(brainImagePrefix + "_rough_brainMask.nrrd",brainImagePrefix + "_brainMask.nrrd")
+    copyfile(brainImageRoughMasked, maskedBrain)
+    copyfile(brainImagePrefix + "_rough_brainMask.nrrd", brainMask)
 
-for f in glob.glob(brainImagePrefix + "_rig*") + glob.glob(brainImagePrefix + "_aff*") \
-         + glob.glob(brainImagePrefix + "_nl*") + glob.glob(brainImagePrefix + "_rough*"):
-    os.remove(f)
+if args.output is None:
+    rmtree(outputFolder)

--- a/brain_extraction/animaAtlasBasedBrainExtraction.py
+++ b/brain_extraction/animaAtlasBasedBrainExtraction.py
@@ -42,7 +42,7 @@ parser.add_argument('-S', '--second-step', action='store_true',
 parser.add_argument('-i', '--input', type=str, required=True, help='File to process')
 parser.add_argument('-m', '--mask', type=str, help='Output path of the brain mask (default is inputName_brainMask.nrrd)')
 parser.add_argument('-b', '--brain', type=str, help='Output path of the masked brain (default is inputName_masked.nrrd)')
-parser.add_argument('-if', '--intermediate_folder', type=str, help="""Path where intermediate files (transformations, transformed images and rough mask) are stored 
+parser.add_argument('-f', '--intermediate_folder', type=str, help="""Path where intermediate files (transformations, transformed images and rough mask) are stored 
                     (default is an temporary directory created automatically and deleted after the process is finished ;
                     intermediate files are deleted by default and kept if this option is given).
                     """)

--- a/brain_extraction/animaAtlasBasedBrainExtraction.py
+++ b/brain_extraction/animaAtlasBasedBrainExtraction.py
@@ -42,7 +42,7 @@ parser.add_argument('-S', '--second-step', action='store_true',
 parser.add_argument('-i', '--input', type=str, required=True, help='File to process')
 parser.add_argument('-m', '--mask', type=str, help='Output path of the brain mask (default is inputName_brainMask.nrrd)')
 parser.add_argument('-b', '--brain', type=str, help='Output path of the masked brain (default is inputName_masked.nrrd)')
-parser.add_argument('-o', '--output', type=str, help="""Path where intermediate files (transformations, transformed images and rough mask) are stored 
+parser.add_argument('-if', '--intermediate_folder', type=str, help="""Path where intermediate files (transformations, transformed images and rough mask) are stored 
                     (default is an temporary directory created automatically and deleted after the process is finished ;
                     intermediate files are deleted by default and kept if this option is given).
                     """)
@@ -68,12 +68,12 @@ if os.path.splitext(brainImage)[1] == '.gz':
 
 brainMask = args.mask if args.mask else brainImagePrefix + "_brainMask.nrrd"
 maskedBrain = args.brain if args.brain else brainImagePrefix + "_masked.nrrd"
-outputFolder = args.output if args.output else tempfile.mkdtemp()
+intermediateFolder = args.intermediate_folder if args.intermediate_folder else tempfile.mkdtemp()
 
-if not os.path.isdir(outputFolder):
-    os.mkdir(outputFolder)
+if not os.path.isdir(intermediateFolder):
+    os.mkdir(intermediateFolder)
 
-brainImagePrefix = os.path.join(outputFolder, os.path.basename(brainImagePrefix))
+brainImagePrefix = os.path.join(intermediateFolder, os.path.basename(brainImagePrefix))
 
 # Decide on whether to use large image setting or small image setting
 command = [animaConvertImage, "-i", brainImage, "-I"]
@@ -144,4 +144,4 @@ else:
     copyfile(brainImagePrefix + "_rough_brainMask.nrrd", brainMask)
 
 if args.output is None:
-    rmtree(outputFolder)
+    rmtree(intermediateFolder)


### PR DESCRIPTION
Added `--brain`, `--mask` and `--output` options to `animaAtlasBasedBrainExtraction.py`:

```
usage: animaAtlasBasedBrainExtraction.py [-h] [-S] -i INPUT [-m MASK]
                                         [-b BRAIN] [-o OUTPUT]

Computes the brain mask of images given in input by registering a known atlas
on it. Their output is prefix_brainMask.nrrd and prefix_masked.nrrd

optional arguments:
  -h, --help            show this help message and exit
  -S, --second-step     Perform second step of atlas based cropping (might
                        crop part of the external part of the brain)
  -i INPUT, --input INPUT
                        File to process
  -m MASK, --mask MASK  Output path of the brain mask (default is
                        inputName_brainMask.nrrd)
  -b BRAIN, --brain BRAIN
                        Output path of the masked brain (default is
                        inputName_masked.nrrd)
  -o OUTPUT, --output OUTPUT
                        Path where intermediate files (transformations,
                        transformed images and rough mask) are stored (default
                        is an temporary directory created automatically and
                        deleted after the process is finished ; intermediate
                        files are deleted by default and kept if this option
                        is given).
```